### PR TITLE
Normalize payloads in serializers

### DIFF
--- a/app/adapters/github-repository.js
+++ b/app/adapters/github-repository.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+  pathForType: function() {
+    return 'repos';
+  }
+});

--- a/app/adapters/github-user.js
+++ b/app/adapters/github-user.js
@@ -10,31 +10,5 @@ export default GithubAdapter.extend({
       builtURL = builtURL.replace('users', 'user');
     }
     return builtURL;
-  },
-  find: function(store, type, id, snapshot) {
-    return this._super(store, type, id, snapshot).then(function(data) {
-      return {
-        githubUser: {
-          id: data.login,
-          name: data.name,
-          avatarUrl: data.avatar_url,
-          links: {
-            githubRepositories: data.repos_url
-          }
-        }
-      };
-    });
-  },
-  findHasMany: function(store, snapshot, url) {
-    return this._super(store, snapshot, url).then(function(data) {
-      return {
-        githubRepositories: data.map(function(item) {
-          return {
-            id: item.full_name,
-            name: item.name
-          };
-        })
-      };
-    });
   }
 });

--- a/app/serializers/github-repository.js
+++ b/app/serializers/github-repository.js
@@ -1,0 +1,19 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({
+  extractArray: function(store, primaryType, payload) {
+    payload = { githubRepositories: payload };
+    return this._super(store, primaryType, payload);
+  },
+  extractSingle: function(store, primaryType, payload, recordId) {
+    payload = { githubRepository: payload };
+    return this._super(store, primaryType, payload, recordId);
+  },
+  normalize: function(type, hash, prop) {
+    hash = {
+      id: hash.full_name,
+      name: hash.name
+    };
+    return this._super(type, hash, prop);
+  }
+});

--- a/app/serializers/github-user.js
+++ b/app/serializers/github-user.js
@@ -1,0 +1,23 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({
+  extractArray: function(store, primaryType, payload) {
+    payload = { githubUsers: payload };
+    return this._super(store, primaryType, payload);
+  },
+  extractSingle: function(store, primaryType, payload, recordId) {
+    payload = { githubUser: payload };
+    return this._super(store, primaryType, payload, recordId);
+  },
+  normalize: function(type, hash, prop) {
+    hash = {
+      id: hash.login,
+      name: hash.name,
+      avatarUrl: hash.avatar_url,
+      links: {
+        githubRepositories: hash.repos_url
+      }
+    };
+    return this._super(type, hash, prop);
+  }
+});

--- a/tests/unit/adapters/github-repository-test.js
+++ b/tests/unit/adapters/github-repository-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('adapter:github-repository', 'GithubRepositoryAdapter', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/serializers/github-repository-test.js
+++ b/tests/unit/serializers/github-repository-test.js
@@ -1,0 +1,18 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+
+moduleForModel('github-repository', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:github-repository']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  var record = this.subject();
+
+  var serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/github-user-test.js
+++ b/tests/unit/serializers/github-user-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+
+moduleForModel('github-user', {
+  // Specify the other units that are required for this test.
+  needs: [
+    'serializer:github-user',
+    'model:githubRepository'
+  ]
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  var record = this.subject();
+
+  var serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});


### PR DESCRIPTION
Do normalizations in serializers so it doesn't have to be repeated for find/findHasMany/findQuery/etc.
